### PR TITLE
Add RSS_FEED_LIMIT environment variable to control feed post count

### DIFF
--- a/packages/core/src/routes/feed/__tests__/rss.test.ts
+++ b/packages/core/src/routes/feed/__tests__/rss.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import type { Bindings } from "../../../types.js";
+import type { AppVariables } from "../../../app.js";
+import { createTestDatabase } from "../../../__tests__/helpers/db.js";
+import { createPostService } from "../../../services/post.js";
+import { createSettingsService } from "../../../services/settings.js";
+import { createMediaService } from "../../../services/media.js";
+import { rssRoutes } from "../rss.js";
+
+type Env = { Bindings: Bindings; Variables: AppVariables };
+
+function createFeedTestApp(envOverrides: Partial<Bindings> = {}) {
+  const { db } = createTestDatabase();
+
+  const services = {
+    posts: createPostService(db as never),
+    settings: createSettingsService(db as never),
+    media: createMediaService(db as never),
+  };
+
+  const app = new Hono<Env>();
+
+  app.use("*", async (c, next) => {
+    c.env = {
+      SITE_URL: "http://localhost:9019",
+      ...envOverrides,
+    } as Bindings;
+
+    c.set("services", services as AppVariables["services"]);
+    c.set("config", {});
+    await next();
+  });
+
+  app.route("/feed", rssRoutes);
+
+  return { app, services };
+}
+
+describe("RSS Feed Routes", () => {
+  describe("RSS_FEED_LIMIT env var", () => {
+    it("defaults to 50 when RSS_FEED_LIMIT is not set", async () => {
+      const { app, services } = createFeedTestApp();
+
+      // Create 3 posts
+      for (let i = 0; i < 3; i++) {
+        await services.posts.create({
+          format: "note",
+          title: `Post ${i}`,
+          body: `Body ${i}`,
+          status: "published",
+        });
+      }
+
+      const res = await app.request("/feed");
+      expect(res.status).toBe(200);
+
+      const xml = await res.text();
+      // All 3 posts should appear (under default limit of 50)
+      expect(xml).toContain("Post 0");
+      expect(xml).toContain("Post 1");
+      expect(xml).toContain("Post 2");
+    });
+
+    it("respects RSS_FEED_LIMIT to limit the number of posts", async () => {
+      const { app, services } = createFeedTestApp({
+        RSS_FEED_LIMIT: "2",
+      });
+
+      // Create 5 posts
+      for (let i = 0; i < 5; i++) {
+        await services.posts.create({
+          format: "note",
+          title: `Post ${i}`,
+          body: `Body ${i}`,
+          status: "published",
+        });
+      }
+
+      const res = await app.request("/feed");
+      expect(res.status).toBe(200);
+
+      const xml = await res.text();
+      // Posts are ordered by publishedAt DESC, so the latest 2 should appear
+      // With same timestamp they fall back to id DESC, so Post 4 and Post 3
+      expect(xml).toContain("Post 4");
+      expect(xml).toContain("Post 3");
+      expect(xml).not.toContain("Post 2");
+      expect(xml).not.toContain("Post 1");
+      expect(xml).not.toContain("Post 0");
+    });
+
+    it("falls back to 50 for invalid RSS_FEED_LIMIT", async () => {
+      const { app, services } = createFeedTestApp({
+        RSS_FEED_LIMIT: "not-a-number",
+      });
+
+      // Create 2 posts
+      for (let i = 0; i < 2; i++) {
+        await services.posts.create({
+          format: "note",
+          title: `Post ${i}`,
+          body: `Body ${i}`,
+          status: "published",
+        });
+      }
+
+      const res = await app.request("/feed");
+      expect(res.status).toBe(200);
+
+      const xml = await res.text();
+      // Both posts should appear (fallback to 50)
+      expect(xml).toContain("Post 0");
+      expect(xml).toContain("Post 1");
+    });
+
+    it("also applies to atom feed", async () => {
+      const { app, services } = createFeedTestApp({
+        RSS_FEED_LIMIT: "1",
+      });
+
+      for (let i = 0; i < 3; i++) {
+        await services.posts.create({
+          format: "note",
+          title: `Post ${i}`,
+          body: `Body ${i}`,
+          status: "published",
+        });
+      }
+
+      const res = await app.request("/feed/atom.xml");
+      expect(res.status).toBe(200);
+
+      const xml = await res.text();
+      // Only the latest post should appear
+      expect(xml).toContain("Post 2");
+      expect(xml).not.toContain("Post 1");
+      expect(xml).not.toContain("Post 0");
+    });
+  });
+});

--- a/packages/core/src/routes/feed/rss.ts
+++ b/packages/core/src/routes/feed/rss.ts
@@ -25,10 +25,12 @@ async function buildFeedData(c: Context<Env>): Promise<FeedData> {
   const siteUrl = c.env.SITE_URL;
   const siteLanguage = await getSiteLanguage(c);
 
+  const feedLimit = parseInt(c.env.RSS_FEED_LIMIT ?? "50", 10) || 50;
+
   const posts = await c.var.services.posts.list({
     status: "published",
     excludeReplies: true,
-    limit: 50,
+    limit: feedLimit,
   });
 
   // Batch load media for enclosures

--- a/packages/core/src/types/bindings.ts
+++ b/packages/core/src/types/bindings.ts
@@ -25,4 +25,6 @@ export interface Bindings {
   S3_SECRET_ACCESS_KEY?: string;
   S3_REGION?: string;
   S3_PUBLIC_URL?: string;
+  // RSS feed
+  RSS_FEED_LIMIT?: string;
 }


### PR DESCRIPTION
## Summary
This PR adds support for configuring the maximum number of posts included in RSS and Atom feeds via the `RSS_FEED_LIMIT` environment variable.

## Key Changes
- Added `RSS_FEED_LIMIT` environment variable to the `Bindings` type with optional string value
- Modified the RSS feed route to parse and use `RSS_FEED_LIMIT` when fetching posts, defaulting to 50 if not set or invalid
- Added comprehensive test suite covering:
  - Default behavior (50 posts when limit not specified)
  - Custom limit enforcement
  - Invalid input handling (falls back to 50)
  - Atom feed support

## Implementation Details
- The limit is parsed as an integer with a fallback to 50 for invalid values using `parseInt(c.env.RSS_FEED_LIMIT ?? "50", 10) || 50`
- Posts are ordered by `publishedAt DESC` (with `id DESC` as tiebreaker), so the most recent posts are included
- The limit applies to both RSS and Atom feed endpoints

https://claude.ai/code/session_017fUfyr89VKCMkDnCf61veu