### PR TITLE
Add dev password setup script for local development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,15 @@ const res = await app.request("/api/posts");
 
 Each test gets a fresh database via `beforeEach`. Don't test third-party internals or JSX rendering.
 
+## Dev Login
+
+After `mise run db-seed`, the database has user/account rows but the password hash is from an export and unusable. Run `mise run dev-password <password>` to set a known password via better-auth's `hashPassword()`. Credentials after setup:
+
+- **Email**: `demo@jant.me`
+- **Password**: whatever you passed to `dev-password`
+- **Login page**: `/signin` → then `/dash` for the dashboard
+- **Remote sessions**: `scripts/setup-remote.sh` auto-runs `db-seed` + `dev-password testtest`, so credentials are `demo@jant.me / testtest`
+
 ## i18n
 
 ```tsx

--- a/mise.toml
+++ b/mise.toml
@@ -148,9 +148,9 @@ echo "Done! Database has been seeded."
 """
 
 [tasks.dev-password]
-description = "Set a known password for the dev user (default: testtest)"
+description = "Set dev login credentials: mise run dev-password <password>"
 dir = "templates/jant-site"
-run = "node scripts/set-dev-password.mjs"
+run = "node scripts/set-dev-password.mjs {{arg(name=\"password\")}}"
 
 # =============================================================================
 # i18n (Lingui)

--- a/mise.toml
+++ b/mise.toml
@@ -147,6 +147,11 @@ pnpm exec wrangler d1 execute DB --local --file=scripts/seed-local.sql
 echo "Done! Database has been seeded."
 """
 
+[tasks.dev-password]
+description = "Set a known password for the dev user (default: testtest)"
+dir = "templates/jant-site"
+run = "node scripts/set-dev-password.mjs"
+
 # =============================================================================
 # i18n (Lingui)
 # =============================================================================

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@eslint/js": "^9.39.2",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.54.0",
+    "better-auth": "^1.4.18",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.37.5",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.54.0
         version: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      better-auth:
+        specifier: ^1.4.18
+        version: 1.4.18(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260207.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(kysely@0.28.11))(react@19.2.4)(vitest@4.0.18(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)

--- a/scripts/setup-remote.sh
+++ b/scripts/setup-remote.sh
@@ -42,3 +42,6 @@ pnpm install
 
 # Set up local database with seed data
 mise run db-seed
+
+# Set a known dev password (testtest) so we can log in
+mise run dev-password

--- a/scripts/setup-remote.sh
+++ b/scripts/setup-remote.sh
@@ -39,3 +39,6 @@ mise install
 
 # Install dependencies
 pnpm install
+
+# Set up local database with seed data
+mise run db-seed

--- a/scripts/setup-remote.sh
+++ b/scripts/setup-remote.sh
@@ -43,5 +43,5 @@ pnpm install
 # Set up local database with seed data
 mise run db-seed
 
-# Set a known dev password (testtest) so we can log in
-mise run dev-password
+# Set dev login credentials (demo@jant.me / testtest)
+mise run dev-password testtest

--- a/templates/jant-site/scripts/set-dev-password.mjs
+++ b/templates/jant-site/scripts/set-dev-password.mjs
@@ -1,36 +1,36 @@
-import { randomBytes, scryptSync } from "crypto";
 import { execSync } from "child_process";
+import { hashPassword } from "better-auth/crypto";
 
 const isRemote = process.argv.includes("--remote");
 const flag = isRemote ? "--remote" : "--local";
 
-const password =
-  process.argv.find(
-    (a) =>
-      !a.startsWith("-") &&
-      a !== process.argv[0] &&
-      a !== process.argv[1] &&
-      a !== "--remote"
-  ) || "testtest";
+const password = process.argv.find(
+  (a) =>
+    !a.startsWith("-") &&
+    a !== process.argv[0] &&
+    a !== process.argv[1] &&
+    a !== "--remote"
+);
 
-// Match better-auth's scrypt parameters exactly:
-// N=16384, r=16, p=1, dkLen=64 (from better-auth/crypto)
-const salt = randomBytes(16).toString("hex");
-const key = scryptSync(password.normalize("NFKC"), salt, 64, {
-  N: 16384,
-  r: 16,
-  p: 1,
-  maxmem: 128 * 16384 * 16 * 2,
-});
-const hashedPassword = `${salt}:${key.toString("hex")}`;
+if (!password) {
+  console.error(
+    "Usage: node scripts/set-dev-password.mjs <password> [--remote]"
+  );
+  process.exit(1);
+}
 
-const sql = `UPDATE account SET password = '${hashedPassword}' WHERE provider_id = 'credential'`;
+const hashedPassword = await hashPassword(password);
+
+const sql = [
+  `UPDATE user SET email = 'demo@jant.me' WHERE role = 'admin'`,
+  `UPDATE account SET password = '${hashedPassword}' WHERE provider_id = 'credential'`,
+].join("; ");
 
 execSync(`npx wrangler d1 execute DB ${flag} --command "${sql}"`, {
   stdio: "inherit",
 });
 
 console.log("");
-console.log("Dev password set successfully.");
-console.log(`  Email: (the admin user in your seed data)`);
+console.log("Dev credentials set successfully.");
+console.log("  Email:    demo@jant.me");
 console.log(`  Password: ${password}`);

--- a/templates/jant-site/scripts/set-dev-password.mjs
+++ b/templates/jant-site/scripts/set-dev-password.mjs
@@ -1,0 +1,36 @@
+import { randomBytes, scryptSync } from "crypto";
+import { execSync } from "child_process";
+
+const isRemote = process.argv.includes("--remote");
+const flag = isRemote ? "--remote" : "--local";
+
+const password =
+  process.argv.find(
+    (a) =>
+      !a.startsWith("-") &&
+      a !== process.argv[0] &&
+      a !== process.argv[1] &&
+      a !== "--remote"
+  ) || "testtest";
+
+// Match better-auth's scrypt parameters exactly:
+// N=16384, r=16, p=1, dkLen=64 (from better-auth/crypto)
+const salt = randomBytes(16).toString("hex");
+const key = scryptSync(password.normalize("NFKC"), salt, 64, {
+  N: 16384,
+  r: 16,
+  p: 1,
+  maxmem: 128 * 16384 * 16 * 2,
+});
+const hashedPassword = `${salt}:${key.toString("hex")}`;
+
+const sql = `UPDATE account SET password = '${hashedPassword}' WHERE provider_id = 'credential'`;
+
+execSync(`npx wrangler d1 execute DB ${flag} --command "${sql}"`, {
+  stdio: "inherit",
+});
+
+console.log("");
+console.log("Dev password set successfully.");
+console.log(`  Email: (the admin user in your seed data)`);
+console.log(`  Password: ${password}`);


### PR DESCRIPTION
## Summary
Add a utility script to set known login credentials for local development, making it easier to test authentication flows after seeding the database.

## Key Changes
- **New script** `scripts/set-dev-password.mjs`: Hashes a provided password using better-auth's `hashPassword()` and updates the database with demo credentials (`demo@jant.me`)
- **New task** `dev-password` in `mise.toml`: Exposes the script as `mise run dev-password <password>`
- **Updated** `scripts/setup-remote.sh`: Auto-runs `dev-password testtest` after `db-seed` to establish consistent remote session credentials
- **Updated** `CLAUDE.md`: Documents the dev login workflow, including the new `dev-password` command and default credentials
- **Added dependency**: `better-auth` to `package.json` for password hashing

## Implementation Details
The script accepts a password argument and an optional `--remote` flag to target either local or remote D1 databases. It updates two database rows:
1. Sets the admin user's email to `demo@jant.me`
2. Sets the account password hash for credential-based authentication

This ensures the password hash is properly generated using better-auth's hashing algorithm, making it compatible with the authentication system.

https://claude.ai/code/session_015MpbZJrj1dH7qguTeCLeS3