### PR TITLE
Add configurable DEFAULT_THEME environment variable

### DIFF
--- a/packages/core/src/app.tsx
+++ b/packages/core/src/app.tsx
@@ -147,9 +147,7 @@ export function createApp(config: JantConfig = {}): App {
         c.var.services.settings.get("SITE_AVATAR"),
       ]);
     const themes = getAvailableThemes(resolvedConfig);
-    const activeTheme = themeId
-      ? themes.find((t) => t.id === themeId)
-      : undefined;
+    const activeTheme = themes.find((t) => t.id === (themeId ?? "halloween"));
 
     // Build font override CSS variables
     const fontTheme = fontThemeId

--- a/packages/core/src/app.tsx
+++ b/packages/core/src/app.tsx
@@ -147,7 +147,8 @@ export function createApp(config: JantConfig = {}): App {
         c.var.services.settings.get("SITE_AVATAR"),
       ]);
     const themes = getAvailableThemes(resolvedConfig);
-    const activeTheme = themes.find((t) => t.id === (themeId ?? "halloween"));
+    const defaultThemeId = c.env.DEFAULT_THEME || "halloween";
+    const activeTheme = themes.find((t) => t.id === (themeId ?? defaultThemeId));
 
     // Build font override CSS variables
     const fontTheme = fontThemeId

--- a/packages/core/src/lib/__tests__/config.test.ts
+++ b/packages/core/src/lib/__tests__/config.test.ts
@@ -172,6 +172,34 @@ describe("isNoIndex", () => {
   });
 });
 
+describe("DEFAULT_THEME", () => {
+  it("returns 'halloween' by default", () => {
+    const c = createMockContext({
+      settings: {} as ReturnType<typeof createSettingsService>,
+    });
+    const result = getConfigFallback(c, "DEFAULT_THEME");
+    expect(result).toBe("halloween");
+  });
+
+  it("returns env value when DEFAULT_THEME is set", () => {
+    const c = createMockContext(
+      { settings: {} as ReturnType<typeof createSettingsService> },
+      { DEFAULT_THEME: "panda" },
+    );
+    const result = getConfigFallback(c, "DEFAULT_THEME");
+    expect(result).toBe("panda");
+  });
+
+  it("is envOnly so getConfig skips DB lookup", async () => {
+    const c = createMockContext(
+      { settings: {} as ReturnType<typeof createSettingsService> },
+      { DEFAULT_THEME: "beach" },
+    );
+    const result = await getConfig(c, "DEFAULT_THEME");
+    expect(result).toBe("beach");
+  });
+});
+
 describe("getConfigFallback", () => {
   it("returns default when no env value", () => {
     const c = createMockContext({

--- a/packages/core/src/routes/dash/settings.tsx
+++ b/packages/core/src/routes/dash/settings.tsx
@@ -330,8 +330,9 @@ settingsRoutes.post("/avatar/display", async (c) => {
 settingsRoutes.get("/appearance", async (c) => {
   const { settings } = c.var.services;
   const siteName = await getSiteName(c);
+  const defaultThemeId = getConfigFallback(c, "DEFAULT_THEME");
   const currentThemeId =
-    (await settings.get(SETTINGS_KEYS.THEME)) ?? "halloween";
+    (await settings.get(SETTINGS_KEYS.THEME)) ?? defaultThemeId;
   const currentFontThemeId = (await settings.get("FONT_THEME")) ?? "default";
   const customCSS = (await settings.get(SETTINGS_KEYS.CUSTOM_CSS)) ?? "";
   const themes = getAvailableThemes(c.var.config);
@@ -366,7 +367,8 @@ settingsRoutes.post("/appearance", async (c) => {
     return dsToast("Invalid theme selected.", "error");
   }
 
-  if (validTheme.id === "halloween") {
+  const defaultThemeId = getConfigFallback(c, "DEFAULT_THEME");
+  if (validTheme.id === defaultThemeId) {
     await settings.remove(SETTINGS_KEYS.THEME);
   } else {
     await settings.set(SETTINGS_KEYS.THEME, validTheme.id);

--- a/packages/core/src/routes/dash/settings.tsx
+++ b/packages/core/src/routes/dash/settings.tsx
@@ -330,7 +330,8 @@ settingsRoutes.post("/avatar/display", async (c) => {
 settingsRoutes.get("/appearance", async (c) => {
   const { settings } = c.var.services;
   const siteName = await getSiteName(c);
-  const currentThemeId = (await settings.get(SETTINGS_KEYS.THEME)) ?? "default";
+  const currentThemeId =
+    (await settings.get(SETTINGS_KEYS.THEME)) ?? "halloween";
   const currentFontThemeId = (await settings.get("FONT_THEME")) ?? "default";
   const customCSS = (await settings.get(SETTINGS_KEYS.CUSTOM_CSS)) ?? "";
   const themes = getAvailableThemes(c.var.config);
@@ -365,7 +366,7 @@ settingsRoutes.post("/appearance", async (c) => {
     return dsToast("Invalid theme selected.", "error");
   }
 
-  if (validTheme.id === "default") {
+  if (validTheme.id === "halloween") {
     await settings.remove(SETTINGS_KEYS.THEME);
   } else {
     await settings.set(SETTINGS_KEYS.THEME, validTheme.id);

--- a/packages/core/src/types/bindings.ts
+++ b/packages/core/src/types/bindings.ts
@@ -6,6 +6,7 @@ export interface Bindings {
   DB: D1Database;
   R2?: R2Bucket;
   SITE_URL: string;
+  DEFAULT_THEME?: string;
   AUTH_SECRET?: string;
   R2_PUBLIC_URL?: string;
   IMAGE_TRANSFORM_URL?: string;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -37,6 +37,10 @@ export const CONFIG_FIELDS = {
   },
 
   // Environment-only (deployment/infrastructure config)
+  DEFAULT_THEME: {
+    defaultValue: "halloween",
+    envOnly: true,
+  },
   SITE_URL: {
     defaultValue: "",
     envOnly: true,

--- a/packages/core/src/ui/color-themes.ts
+++ b/packages/core/src/ui/color-themes.ts
@@ -150,7 +150,7 @@ export const BUILTIN_COLOR_THEMES: ColorTheme[] = [
   }),
 
   {
-    id: "default",
+    id: "panda",
     name: "Panda",
     light: {},
     dark: {},


### PR DESCRIPTION
## Summary
This PR introduces a new `DEFAULT_THEME` environment variable that allows deployment-level configuration of the default theme, replacing the hardcoded "default" theme fallback.

## Key Changes
- Added `DEFAULT_THEME` as an environment-only config field with "halloween" as the default value
- Updated the appearance settings route to use the configurable default theme instead of hardcoded "default"
- Modified theme selection logic in `app.tsx` to respect the `DEFAULT_THEME` environment variable
- Renamed the "default" color theme to "panda" to avoid naming confusion with the default fallback behavior
- Added `DEFAULT_THEME` binding to the Cloudflare Workers bindings interface
- Added comprehensive test coverage for the new `DEFAULT_THEME` configuration

## Implementation Details
- The `DEFAULT_THEME` config is marked as `envOnly: true`, meaning it's only read from environment variables and not from the database
- When no theme is explicitly selected by the user, the system now falls back to the `DEFAULT_THEME` environment variable (or "halloween" if not set)
- The settings removal logic now correctly compares against the configurable default theme ID rather than the hardcoded "default" string

https://claude.ai/code/session_013C9kZegaBepMUpnQbGbw77