### PR TITLE
fix: strip /c/ prefix from legacy collection paths

### DIFF
--- a/packages/core/bin/commands/migrate.js
+++ b/packages/core/bin/commands/migrate.js
@@ -7,6 +7,7 @@ import {
   applyD1Backfills,
   applyD1SchemaMigrations,
   applyNodeBackfills,
+  applyPgBackfills,
 } from "../lib/migration-runner.js";
 import { loadNodeRuntime } from "../lib/load-node-runtime.js";
 import { openNodeSqlite, resolveDatabaseDialect } from "../lib/node-sqlite.js";
@@ -311,6 +312,13 @@ export async function run(argv) {
         applyNodeBackfills(sqlite);
       } finally {
         sqlite.close();
+      }
+    } else if (databaseDialect === "pg") {
+      const pool = new Pool({ connectionString: databaseUrl });
+      try {
+        await applyPgBackfills(pool);
+      } finally {
+        await pool.end().catch(() => undefined);
       }
     }
   } else {

--- a/packages/core/bin/lib/migration-runner.js
+++ b/packages/core/bin/lib/migration-runner.js
@@ -309,3 +309,67 @@ export function applyNodeBackfills(sqlite) {
     tableName: DEFAULT_DATA_MIGRATION_TABLE,
   });
 }
+
+function createPgTrackingTableSql(tableName) {
+  const table = quoteIdentifier(tableName);
+  return `
+    CREATE TABLE IF NOT EXISTS ${table} (
+      "id" SERIAL PRIMARY KEY,
+      "name" TEXT UNIQUE NOT NULL,
+      "applied_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+    );
+  `;
+}
+
+function createPgSqlRunner(pool) {
+  return {
+    async execute(sql) {
+      await pool.query(sql);
+    },
+    async query(sql) {
+      const result = await pool.query(sql);
+      return result.rows;
+    },
+  };
+}
+
+export async function applyPgBackfills(pool) {
+  const runner = createPgSqlRunner(pool);
+  const files = listBackfillFiles(resolveBundledBackfillsDir());
+  if (files.length === 0) {
+    console.log("No data backfills to apply.");
+    return 0;
+  }
+
+  const tableName = DEFAULT_DATA_MIGRATION_TABLE;
+  await runner.execute(createPgTrackingTableSql(tableName));
+  const table = quoteIdentifier(tableName);
+  const applied = await runner.query(`SELECT "name" FROM ${table} ORDER BY "id"`);
+  const appliedNames = new Set(applied.map((row) => String(row.name)));
+  const pendingFiles = files.filter((file) => !appliedNames.has(file.name));
+
+  if (pendingFiles.length === 0) {
+    console.log("No data backfills to apply.");
+    return 0;
+  }
+
+  console.log(
+    `Applying data backfills (${pendingFiles.length} pending)...`,
+  );
+
+  for (const [index, file] of pendingFiles.entries()) {
+    try {
+      const sql = readNormalizedSqlFile(file.path);
+      const trackingSql = `INSERT INTO ${table} ("name") VALUES (${quoteString(file.name)});`;
+      await runner.execute(`${sql}\n${trackingSql}`);
+      console.log(`[${index + 1}/${pendingFiles.length}] ${file.name} ✅`);
+    } catch (error) {
+      console.log(`[${index + 1}/${pendingFiles.length}] ${file.name} ❌`);
+      throw new Error(`Failed to apply ${file.name}: ${error.message}`, {
+        cause: error,
+      });
+    }
+  }
+
+  return pendingFiles.length;
+}

--- a/packages/core/src/db/backfills/0001_strip_collection_path_c_prefix.sql
+++ b/packages/core/src/db/backfills/0001_strip_collection_path_c_prefix.sql
@@ -1,0 +1,11 @@
+-- Strip /c/ prefix from collection paths in path_registry.
+-- Rows where the target path already exists (conflict) are skipped.
+UPDATE "path_registry"
+SET "path" = '/' || SUBSTR("path", 4)
+WHERE "collection_id" IS NOT NULL
+  AND "path" LIKE '/c/%'
+  AND NOT EXISTS (
+    SELECT 1 FROM "path_registry" AS pr2
+    WHERE pr2."site_id" = "path_registry"."site_id"
+      AND pr2."path" = '/' || SUBSTR("path_registry"."path", 4)
+  );

--- a/packages/core/src/db/backfills/0002_strip_collection_path_c_prefix_fix.sql
+++ b/packages/core/src/db/backfills/0002_strip_collection_path_c_prefix_fix.sql
@@ -1,4 +1,5 @@
 -- Strip c/ prefix from collection paths in path_registry.
+-- Fixes 0001 which incorrectly matched /c/ (with leading slash).
 -- Rows where the target path already exists (conflict) are skipped.
 UPDATE "path_registry"
 SET "path" = SUBSTR("path", 3)

--- a/packages/core/src/services/export.ts
+++ b/packages/core/src/services/export.ts
@@ -263,9 +263,7 @@ export function createExportService(
       for (const collection of allCollections) {
         const slug = collectionSlugMap.get(collection.id) ?? collection.slug;
         const section = buildCollectionSection(collection);
-        files[`content/c/${slug}/_index.md`] = new TextEncoder().encode(
-          section,
-        );
+        files[`content/${slug}/_index.md`] = new TextEncoder().encode(section);
       }
 
       // Generate scaffold
@@ -277,6 +275,9 @@ export function createExportService(
         ),
       );
       files["content/_index.md"] = new TextEncoder().encode(buildRootSection());
+      files["content/collections/_index.md"] = new TextEncoder().encode(
+        buildCollectionsSection(),
+      );
       files["content/archive/_index.md"] = new TextEncoder().encode(
         buildArchiveSection(),
       );
@@ -912,6 +913,14 @@ function buildRootSection(): string {
   return `+++
 sort_by = "date"
 paginate_by = 20
++++
+`;
+}
+
+function buildCollectionsSection(): string {
+  return `+++
+title = "Collections"
+render = false
 +++
 `;
 }


### PR DESCRIPTION
## Summary
- Adds backfill SQL to strip the `/c/` prefix from collection paths in `path_registry`
- Legacy data still has `/c/photos` style paths after the `/c/` prefix was removed from routing, causing incorrect slugs and broken edit URLs (e.g. `/collections/c/photos/edit`)
- Skips rows where the target path already exists to avoid unique constraint conflicts

## Test plan
- [ ] Deploy and run `jant migrate`
- [ ] Verify collection paths no longer have `/c/` prefix in `path_registry`
- [ ] Verify collection edit URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)