### PR TITLE
Add bundleMedia option to control media export strategy

### DIFF
--- a/packages/core/src/__tests__/export-service.test.ts
+++ b/packages/core/src/__tests__/export-service.test.ts
@@ -800,4 +800,131 @@ describe("createExportService (Hugo)", () => {
     const files = filesToMap(await service.generateHugoFiles());
     expect(files.has("static/media/med-x.webp")).toBe(false);
   });
+
+  it("Sync mode (bundleMedia false) links media by absolute site URL without reading bytes", async () => {
+    const root = makePost({ id: "post-root", slug: "with-media" });
+    const media = makeMedia({
+      id: "med-1",
+      filename: "photo.webp",
+      storageKey: "media/med-1.webp",
+    });
+    const storage = {
+      // Must NOT be called — Sync links by URL, never reads attachment bytes.
+      get: async () => {
+        throw new Error("storage.get should not be called in Sync mode");
+      },
+    };
+    const service = createExportService(
+      buildServices({
+        posts: [root],
+        mediaByPost: new Map([["post-root", [media]]]),
+      }),
+      makeSiteConfig(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { storage: storage as any, bundleMedia: false },
+    );
+    const files = filesToMap(await service.generateHugoFiles());
+    expect(files.has("static/media/med-1.webp")).toBe(false);
+    const { frontMatter } = await parseFrontMatter(
+      files.get("content/with-media/_index.md") as string,
+    );
+    const entry = frontMatter.media![0];
+    expect(entry.src).toBe("https://example.com/media/med-1.webp");
+    expect(entry.storage_key).toBe("media/med-1.webp");
+  });
+
+  it("Sync mode links the video poster by absolute site URL without bundling", async () => {
+    const root = makePost({ id: "post-root", slug: "with-video" });
+    const videoMedia = makeMedia({
+      id: "med-video",
+      filename: "clip.mp4",
+      mimeType: "video/mp4",
+      storageKey: "media/med-video.mp4",
+      mediaKind: "video",
+      posterKey: "media/posters/med-video.webp",
+    });
+    const storage = {
+      get: async () => {
+        throw new Error("storage.get should not be called in Sync mode");
+      },
+    };
+    const service = createExportService(
+      buildServices({
+        posts: [root],
+        mediaByPost: new Map([["post-root", [videoMedia]]]),
+      }),
+      makeSiteConfig(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { storage: storage as any, bundleMedia: false },
+    );
+    const files = filesToMap(await service.generateHugoFiles());
+    expect(files.has("static/media/med-video.mp4")).toBe(false);
+    expect(files.has("static/media/med-video-poster.webp")).toBe(false);
+    const { frontMatter } = await parseFrontMatter(
+      files.get("content/with-video/_index.md") as string,
+    );
+    const entry = frontMatter.media![0];
+    expect(entry.src).toBe("https://example.com/media/med-video.mp4");
+    expect(entry.poster).toBe(
+      "https://example.com/media/posters/med-video.webp",
+    );
+  });
+
+  it("Sync mode still prefers a dedicated provider public URL when configured", async () => {
+    const root = makePost({ id: "post-root", slug: "with-cdn" });
+    const media = makeMedia({
+      id: "med-cdn",
+      filename: "cdn.webp",
+      storageKey: "media/med-cdn.webp",
+    });
+    const service = createExportService(
+      buildServices({
+        posts: [root],
+        mediaByPost: new Map([["post-root", [media]]]),
+      }),
+      makeSiteConfig({ r2PublicUrl: "https://cdn.example.com" }),
+      { bundleMedia: false },
+    );
+    const files = filesToMap(await service.generateHugoFiles());
+    expect(files.has("static/media/med-cdn.webp")).toBe(false);
+    const { frontMatter } = await parseFrontMatter(
+      files.get("content/with-cdn/_index.md") as string,
+    );
+    expect(frontMatter.media![0].src).toBe(
+      "https://cdn.example.com/media/med-cdn.webp",
+    );
+  });
+
+  it("Sync mode falls back to bundling bytes when the site URL is unknown", async () => {
+    const root = makePost({ id: "post-root", slug: "with-media" });
+    const media = makeMedia({
+      id: "med-1",
+      filename: "photo.webp",
+      storageKey: "media/med-1.webp",
+    });
+    const storage = {
+      get: async (key: string) =>
+        key === "media/med-1.webp"
+          ? { body: new Blob([new Uint8Array([1, 2, 3])]).stream() }
+          : null,
+    };
+    const service = createExportService(
+      buildServices({
+        posts: [root],
+        mediaByPost: new Map([["post-root", [media]]]),
+      }),
+      makeSiteConfig({ siteUrl: "" }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { storage: storage as any, bundleMedia: false },
+    );
+    const files = filesToMap(await service.generateHugoFiles());
+    // No resolvable URL — bundling is the only way to avoid a broken link.
+    expect(files.get("static/media/med-1.webp")).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+    const { frontMatter } = await parseFrontMatter(
+      files.get("content/with-media/_index.md") as string,
+    );
+    expect(frontMatter.media![0].src).toBe("/media/med-1.webp");
+  });
 });

--- a/packages/core/src/lib/github-sync-site-config.ts
+++ b/packages/core/src/lib/github-sync-site-config.ts
@@ -5,8 +5,10 @@
  * call site had its own near-identical copy.
  *
  * The shape mirrors `routes/api/export.ts` so `jant site export` and
- * `jant github sync` produce byte-identical Hugo sites (modulo media
- * files, which Sync intentionally skips). If you add a field to the
+ * `jant github sync` produce matching Hugo sites. They differ only in
+ * media: `site export` bundles attachment bytes into `static/media/` for
+ * a self-contained archive, while Sync links attachments by URL and
+ * never writes their bytes into the repo. If you add a field to the
  * export route, add it here too.
  */
 

--- a/packages/core/src/services/export.ts
+++ b/packages/core/src/services/export.ts
@@ -227,7 +227,17 @@ export function createExportService(
     media: MediaService;
   },
   siteConfig: SiteConfig,
-  deps: { storage?: StorageDriver | null } = {},
+  deps: {
+    storage?: StorageDriver | null;
+    /**
+     * Whether to bundle media bytes into the exported site under
+     * `static/media/`. Defaults to `true` (the `jant site export`
+     * archive, which must be self-contained). GitHub Sync passes
+     * `false` so media is linked by URL instead — it never reads or
+     * base64-encodes attachment bytes.
+     */
+    bundleMedia?: boolean;
+  } = {},
 ): ExportService {
   return {
     async generateHugoFiles() {
@@ -308,6 +318,7 @@ export function createExportService(
 
       // 3. Build file list
       const exportFiles: ExportFile[] = [];
+      const bundleMedia = deps.bundleMedia ?? true;
 
       // Generate thread bundles (root _index.md + per-reply index.md).
       for (const root of roots) {
@@ -335,6 +346,7 @@ export function createExportService(
           rawMediaByPost,
           siteConfig,
           deps.storage ?? null,
+          bundleMedia,
         );
         exportFiles.push(...bundleFiles);
       }
@@ -662,14 +674,13 @@ interface MediaEmission {
   entry: JantMedia;
   /**
    * Site-relative path under `static/` where the primary bytes should
-   * land, or null when the media links to a remote public URL and no
-   * bytes need to be emitted.
+   * land, or null when the media is linked by URL and no bytes need to
+   * be emitted.
    */
   inlinePath: string | null;
   /**
    * Site-relative path under `static/` where the poster bytes should
-   * land, or null when there's no poster or the poster is linked via
-   * a public URL.
+   * land, or null when there's no poster or the poster is linked by URL.
    */
   inlinePosterPath: string | null;
 }
@@ -682,26 +693,42 @@ interface MediaEmission {
  * When the media's provider has a reachable public URL (R2/S3/local
  * proxy configured with a `*_public_url`), `src` points at that absolute
  * URL and no bytes are emitted — the exported site stays small and the
- * media keeps being served from wherever it already lives. Without a
- * public URL the bytes are written to `static/media/{id}.ext` and `src`
- * is the site-relative path.
+ * media keeps being served from wherever it already lives.
+ *
+ * Otherwise behavior depends on `bundleMedia`:
+ * - `true` (the `jant site export` archive): bytes are written to
+ *   `static/media/{id}.ext` and `src` is the site-relative path, so the
+ *   archive is self-contained.
+ * - `false` (GitHub Sync): no bytes are emitted. `src` falls back to the
+ *   site's own URL so it stays an absolute, resolvable link — the worker
+ *   already serves these objects at `/{storageKey}`. This keeps Sync
+ *   from reading and base64-encoding every attachment on every push.
+ *
+ * When `bundleMedia` is false but the site URL is unknown, bundling is
+ * used as a last resort to avoid emitting a broken relative link.
  */
 function buildMediaEmission(
   media: Media,
   siteConfig: SiteConfig,
+  bundleMedia: boolean,
 ): MediaEmission {
-  const publicUrl = getPublicUrlForProvider(
+  const dedicatedPublicUrl = getPublicUrlForProvider(
     media.provider,
     siteConfig.r2PublicUrl,
     siteConfig.s3PublicUrl,
     siteConfig.localPublicUrl,
   );
-  const hasPublic = Boolean(publicUrl);
+  const siteFallbackUrl =
+    !bundleMedia && siteConfig.siteUrl.trim() ? siteConfig.siteUrl : undefined;
+  const mediaBaseUrl = dedicatedPublicUrl || siteFallbackUrl;
+  const hasRemoteUrl = Boolean(mediaBaseUrl);
 
   const ext = extOfFilename(media.filename);
   const localName = `${media.id}${ext}`;
   const localPath = `/media/${localName}`;
-  const src = hasPublic ? getMediaUrl(media.storageKey, publicUrl) : localPath;
+  const src = hasRemoteUrl
+    ? getMediaUrl(media.storageKey, mediaBaseUrl)
+    : localPath;
 
   const entry: JantMedia = {
     id: media.id,
@@ -730,18 +757,18 @@ function buildMediaEmission(
   if (media.posterKey) {
     const posterExt = extOfStorageKey(media.posterKey);
     const posterLocalName = `${media.id}-poster.${posterExt}`;
-    entry.poster = hasPublic
-      ? getMediaUrl(media.posterKey, publicUrl)
+    entry.poster = hasRemoteUrl
+      ? getMediaUrl(media.posterKey, mediaBaseUrl)
       : `/media/${posterLocalName}`;
     entry.poster_key = media.posterKey;
-    if (!hasPublic) {
+    if (!hasRemoteUrl) {
       inlinePosterPath = `static/media/${posterLocalName}`;
     }
   }
 
   return {
     entry,
-    inlinePath: hasPublic ? null : `static/media/${localName}`,
+    inlinePath: hasRemoteUrl ? null : `static/media/${localName}`,
     inlinePosterPath,
   };
 }
@@ -793,6 +820,7 @@ async function buildThreadBundle(
   mediaByPost: Map<string, Media[]>,
   siteConfig: SiteConfig,
   storage: StorageDriver | null,
+  bundleMedia: boolean,
 ): Promise<ExportFile[]> {
   const files: ExportFile[] = [];
 
@@ -807,7 +835,9 @@ async function buildThreadBundle(
 
   // Root front matter.
   const rootMedia = mediaByPost.get(root.id) ?? [];
-  const rootEmissions = rootMedia.map((m) => buildMediaEmission(m, siteConfig));
+  const rootEmissions = rootMedia.map((m) =>
+    buildMediaEmission(m, siteConfig, bundleMedia),
+  );
   const rootMediaList = rootEmissions.map((e) => e.entry);
   const rootFrontMatter: HugoFrontMatter = {
     id: root.id,
@@ -894,7 +924,7 @@ async function buildThreadBundle(
     const replySlug = slugMap.get(reply.id) ?? reply.slug;
     const replyMedia = mediaByPost.get(reply.id) ?? [];
     const replyEmissions = replyMedia.map((m) =>
-      buildMediaEmission(m, siteConfig),
+      buildMediaEmission(m, siteConfig, bundleMedia),
     );
     const replyMediaList = replyEmissions.map((e) => e.entry);
     const replyCollectionEntries = buildExportedCollectionEntriesForPost(

--- a/packages/core/src/services/github-sync.ts
+++ b/packages/core/src/services/github-sync.ts
@@ -451,8 +451,14 @@ export function createGitHubSyncService(
       if (!config) throw new Error("GitHub Sync is not configured");
       const { client, owner, repo } = createClient(config);
 
-      // Generate full Hugo site via the shared export service
-      const exportService = createExportService(services, siteConfig, deps);
+      // Generate full Hugo site via the shared export service.
+      // `bundleMedia: false` — Sync links attachments by URL instead of
+      // writing their bytes into the repo, so a push never reads or
+      // base64-encodes media. Media stays served from the live site.
+      const exportService = createExportService(services, siteConfig, {
+        storage: deps.storage,
+        bundleMedia: false,
+      });
       const exportFiles = await exportService.generateHugoFiles();
 
       // Resolve HEAD before building the tree — needed as the commit


### PR DESCRIPTION
## Summary
Adds a `bundleMedia` configuration option to the export service that allows media to be linked by URL instead of bundled into the exported site. This enables GitHub Sync to avoid reading and base64-encoding attachment bytes on every push while keeping media links resolvable.

## Key Changes
- **Export service API**: Added `bundleMedia` parameter (defaults to `true`) to `createExportService()` to control whether media bytes are written to `static/media/` or linked by URL
- **Media emission logic**: Updated `buildMediaEmission()` to:
  - Prefer dedicated provider public URLs (R2/S3) when configured
  - Fall back to the site's own URL when `bundleMedia: false` and a site URL is configured
  - Only bundle bytes when no remote URL is available or as a last resort when the site URL is unknown
- **GitHub Sync integration**: Passes `bundleMedia: false` when creating the export service, so media is linked by absolute site URL instead of being written to the repository
- **Documentation**: Updated comments to clarify the three media handling strategies and when each is used

## Implementation Details
- When `bundleMedia: false` and a site URL exists, media `src` points to the site's own URL (e.g., `https://example.com/media/med-1.webp`), relying on the worker to serve objects at `/{storageKey}`
- Poster images follow the same logic as primary media
- If `bundleMedia: false` but the site URL is empty/unknown, the service falls back to bundling bytes to avoid emitting broken relative links
- The default behavior (`bundleMedia: true`) remains unchanged for `jant site export`, producing self-contained archives

https://claude.ai/code/session_01T3BxWKubo3FjfgGFRgxWod